### PR TITLE
add --preserve-boot1 bool flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ mtk-flash --da <PATH> [--fip <PATH>] [--img <PATH>] --dev <DEVICE> [--gpio <CHIP
 - `--img <PATH>` *(optional)*: Path to the system image.
 - `--dev <DEVICE>`: Serial device path.
 - `--gpio <CHIP>` *(optional)*: Path to the GPIO chip device for controlling power, reset and download mode.
+- `--preserve-boot1` *(optional)*: Do not erase `mmc0boot1` after flashing FIP. This is useful for boards/setups where `mmc0boot1` stores u-boot environment (for example, stable MAC addresses) that should be preserved.
 
 ## Troubleshooting
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 #[derive(Parser)]
 #[clap(
-    override_usage = "mtk-flash --da <PATH> [--fip <PATH>] [--img <PATH>] --dev <DEVICE> [--gpio <CHIP>]",
+    override_usage = "mtk-flash --da <PATH> [--fip <PATH>] [--img <PATH>] --dev <DEVICE> [--gpio <CHIP>] [--preserve-boot1]",
     about = "A command-line utility for flashing raw images to MediaTek devices.",
     version = env!("CARGO_PKG_VERSION")
 )]
@@ -37,6 +37,9 @@ pub struct Args {
         help = "Optional path to gpiochip for controlling power, reset and download mode (e.g. /dev/gpiochip0)"
     )]
     pub gpio: Option<PathBuf>,
+
+    #[clap(long, help = "Do not erase mmc0boot1 after flashing FIP.")]
+    pub preserve_boot1: bool,
 }
 
 impl Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,12 @@ async fn main() -> Result<()> {
         println!("\nFlashing FIP to mmc0boot0...");
         flash::flash(&mut fb, "mmc0boot0", fip, interrupt_state.clone()).await?;
 
-        println!("\nErasing mmc0boot1...");
-        fb.erase("mmc0boot1").await?;
+        if args.preserve_boot1 {
+            println!("\nPreserving mmc0boot1...");
+        } else {
+            println!("\nErasing mmc0boot1...");
+            fb.erase("mmc0boot1").await?;
+        }
     } else {
         println!("\nNo FIP image provided, skipping mmc0boot0 flash.");
     }

--- a/tests/args.rs
+++ b/tests/args.rs
@@ -59,3 +59,19 @@ fn fails_with_missing_dev() {
         .failure()
         .stderr(contains("required arguments were not provided"));
 }
+
+#[test]
+fn parses_no_erase_boot1_flag() {
+    let args = Args::parse_from([
+        "test",
+        "--da",
+        "boot/lk.img",
+        "--dev",
+        "/dev/ttyUSB0",
+        "--preserve-boot1",
+    ]);
+    assert!(args.preserve_boot1);
+
+    let args = Args::parse_from(["test", "--da", "boot/lk.img", "--dev", "/dev/ttyUSB0"]);
+    assert!(!args.preserve_boot1);
+}


### PR DESCRIPTION
#### add --preserve-boot1 bool flag

This might be useful for setups where mmc0boot1 stores u-boot environment, and might contain for example MAC addresses that one wants to preserve across flashes